### PR TITLE
Add an instance of Profiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ use Aura\Sql\ExtendedPdo;
 use Aura\SqlMapper_Bundle\Query\ConnectedQueryFactory;
 use Aura\SqlMapper_Bundle\Filter;
 use Aura\SqlQuery\QueryFactory;
+use Aura\Sql\Profiler;
 
+$profiler = new Profiler();
 $connection_locator = new ConnectionLocator(function () use ($profiler) {
     $pdo = new ExtendedPdo('sqlite::memory:');
     $pdo->setProfiler($profiler);


### PR DESCRIPTION
Allows example code to function correctly as originally outlined with a Profiler instance passed to the callable.
