### PR TITLE
Correct method docblocks.

### DIFF
--- a/src/Query/Select.php
+++ b/src/Query/Select.php
@@ -42,13 +42,6 @@ class Select extends AbstractConnectedQuery
      * Fetches a sequential array of rows from the database; the rows
      * are represented as associative arrays.
      *
-     * @param string $statement The SQL statement to prepare and execute.
-     *
-     * @param array $values Values to bind to the query.
-     *
-     * @param callable $callable A callable to be applied to each of the rows
-     * to be returned.
-     *
      * @return array
      *
      */
@@ -69,13 +62,6 @@ class Select extends AbstractConnectedQuery
      * N.b.: if multiple rows have the same first column value, the last
      * row with that value will override earlier rows.
      *
-     * @param string $statement The SQL statement to prepare and execute.
-     *
-     * @param array $values Values to bind to the query.
-     *
-     * @param callable $callable A callable to be applied to each of the rows
-     * to be returned.
-     *
      * @return array
      *
      */
@@ -90,13 +76,6 @@ class Select extends AbstractConnectedQuery
     /**
      *
      * Fetches the first column of rows as a sequential array.
-     *
-     * @param string $statement The SQL statement to prepare and execute.
-     *
-     * @param array $values Values to bind to the query.
-     *
-     * @param callable $callable A callable to be applied to each of the rows
-     * to be returned.
      *
      * @return array
      *
@@ -119,10 +98,6 @@ class Select extends AbstractConnectedQuery
      * in the constructor, you will be overwriting the values injected by
      * fetchObject() !"
      * <http://www.php.net/manual/en/connectionstatement.fetchobject.php#111744>
-     *
-     * @param string $statement The SQL statement to prepare and execute.
-     *
-     * @param array $values Values to bind to the query.
      *
      * @param string $class_name The name of the class to create.
      *
@@ -155,10 +130,6 @@ class Select extends AbstractConnectedQuery
      * fetchObject() !"
      * <http://www.php.net/manual/en/connectionstatement.fetchobject.php#111744>
      *
-     * @param string $statement The SQL statement to prepare and execute.
-     *
-     * @param array $values Values to bind to the query.
-     *
      * @param string $class_name The name of the class to create from each
      * row.
      *
@@ -184,10 +155,6 @@ class Select extends AbstractConnectedQuery
      *
      * Fetches one row from the database as an associative array.
      *
-     * @param string $statement The SQL statement to prepare and execute.
-     *
-     * @param array $values Values to bind to the query.
-     *
      * @return array
      *
      */
@@ -203,11 +170,6 @@ class Select extends AbstractConnectedQuery
      *
      * Fetches an associative array of rows as key-value pairs (first
      * column is the key, second column is the value).
-     *
-     * @param string $statement The SQL statement to prepare and execute.
-     *
-     * @param callable $callable A callable to be applied to each of the rows
-     * to be returned.
      *
      * @param array $values Values to bind to the query.
      *
@@ -225,10 +187,6 @@ class Select extends AbstractConnectedQuery
     /**
      *
      * Fetches the very first value (i.e., first column of the first row).
-     *
-     * @param string $statement The SQL statement to prepare and execute.
-     *
-     * @param array $values Values to bind to the query.
      *
      * @return mixed
      *


### PR DESCRIPTION
Extraneous, non-existent method parameters were documented.  Documentation did not match actual signature.
